### PR TITLE
Reuse cell style if applied to multiple cells instead of creating new one for each cell

### DIFF
--- a/src/main/scala/info.folone/scala.poi/Workbook.scala
+++ b/src/main/scala/info.folone/scala.poi/Workbook.scala
@@ -64,9 +64,10 @@ class Workbook(val sheetMap: Map[String, Sheet], format: WorkbookVersion = HSSF)
 
     styles.keys.foreach { s ⇒
       val cellAddresses = styles(s)
+      val cellStyle = pStyle(s)
       cellAddresses.foreach { addr ⇒
         val cell = wb.getSheet(addr.sheet).getRow(addr.row).getCell(addr.col)
-        cell setCellStyle pStyle(s)
+        cell setCellStyle cellStyle
       }
     }
     wb


### PR DESCRIPTION
When creating brand new cell style object for each cell (in case of multiple cells sharing this style) MS Excel complains that it has max number of fonts exceeded. This in turn causes some styles to be not rendered properly.