### PR TITLE
Correct zero height line

### DIFF
--- a/src/main/scala/info.folone/scala.poi/Workbook.scala
+++ b/src/main/scala/info.folone/scala.poi/Workbook.scala
@@ -23,7 +23,7 @@ class Workbook(val sheetMap: Map[String, Sheet], format: WorkbookVersion = HSSF)
     cell match {
       case StringCell(index, data)  ⇒
         poiCell.setCellValue(data)
-        val height = data.split("\n").size * row.getHeight
+        val height = (data.split("\n").size + 1) * row.getHeight
         row setHeight height.asInstanceOf[Short]
       case BooleanCell(index, data) ⇒ poiCell.setCellValue(data)
       case NumericCell(index, data) ⇒ poiCell.setCellValue(data)


### PR DESCRIPTION
Correct line with height set to 0, if cell with no '\n'

the row height is defined by the number of lines of the last cell of the row. it's still not what we should want but it's better