### PR TITLE
unlimited rowAccessWindowSize to export large file

### DIFF
--- a/src/main/scala/info.folone/scala.poi/Workbook.scala
+++ b/src/main/scala/info.folone/scala.poi/Workbook.scala
@@ -36,7 +36,7 @@ class Workbook(val sheetMap: Map[String, Sheet], format: WorkbookVersion = HSSF)
     val workbook = format match {
       case HSSF ⇒ new org.apache.poi.hssf.usermodel.HSSFWorkbook
       case XSSF ⇒ new org.apache.poi.xssf.usermodel.XSSFWorkbook
-      case SXSSF ⇒ new org.apache.poi.xssf.streaming.SXSSFWorkbook
+      case SXSSF ⇒ new org.apache.poi.xssf.streaming.SXSSFWorkbook(-1)
     }
     sheets foreach { sh ⇒
       val Sheet((name), (rows)) = sh


### PR DESCRIPTION
I want to use sxssf for my system( with xssf, it spent a lot of RAM and we got OutOfMemory). This trick  can help to solve the  exception when to export a large xls file (~ 20 MB) as below:

```
java.lang.IllegalArgumentException:Attempting to write a row[365] in the range [0,1385] that is already written to disk.
()

java.lang.IllegalArgumentException: Attempting to write a row[365] in the range [0,1385] that is already written to disk.
    at org.apache.poi.xssf.streaming.SXSSFSheet.createRow(SXSSFSheet.java:126)

```
