### PR TITLE
Revert "Update sbt-ci-release to 1.11.0"

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,4 +2,4 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.4")
 
-addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.0")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.9.3")


### PR DESCRIPTION
Reverts folone/poi.scala#312

This broke snapshot publishing. Reverting until I can figure out why.