### PR TITLE
Revert "Update sbt, scripted-plugin to 1.11.0"

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.11.0
+sbt.version=1.10.11


### PR DESCRIPTION
Reverts folone/poi.scala#311

This broke SNAPSHOT publishing, reverting until I figure out why.