### PR TITLE
Introduce a separate benchmark workflow.

### DIFF
--- a/.github/workflows/benchmark-comment.yml
+++ b/.github/workflows/benchmark-comment.yml
@@ -1,0 +1,58 @@
+name: Benchmark Comment
+
+on:
+  workflow_run:
+    workflows: ["CI Pipeline"]
+    types:
+      - completed
+
+jobs:
+  benchmark-comment:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Download benchmark results
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "benchmark-results"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: matchArtifact.id,
+              archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/benchmark-results.zip`, Buffer.from(download.data));
+      - name: Unzip benchmark results
+        run: unzip benchmark-results.zip
+
+      - name: Compare benchmark results
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: JMH Benchmarks
+          tool: 'jmh'
+          output-file-path: benchmark-results.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          # Do not fail the build, just comment on the PR.
+          fail-on-alert: false
+
+      - name: Post benchmark page link
+        if: github.event.workflow_run.event == 'pull_request'
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          body: |
+            📊 **Benchmark Results**
+
+            The detailed benchmark results are available for review on our website.
+
+            [View Benchmark Report](https://g.omg.lol/poi.scala/dev/bench/)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,25 +145,11 @@ jobs:
     - name: Run JMH benchmarks
       run: |
         sbt "benchmarks/Jmh/run -rf json -rff benchmark-results.json .*PoiBenchmarks.*" || echo "Benchmarks failed but continuing"
-    - name: Compare benchmark results
-      uses: benchmark-action/github-action-benchmark@v1
+    - name: Store benchmark results
+      uses: actions/upload-artifact@v4
       with:
-        name: JMH Benchmarks
-        tool: 'jmh'
-        output-file-path: benchmarks/benchmark-results.json
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        auto-push: true
-        # Do not fail the build, just comment on the PR.
-        fail-on-alert: false
-    - name: Post benchmark page link
-      if: github.event_name == 'pull_request'
-      uses: peter-evans/create-or-update-comment@v4
-      with:
-        issue-number: ${{ github.event.pull_request.number }}
-        body: |
-          📊 **Benchmark Results**
-
-          [View Benchmark Report](https://folone.github.io/poi.scala/dev/bench/)
+        name: benchmark-results
+        path: benchmarks/benchmark-results.json
 
   memory-testing:
     name: Memory & Stress Testing


### PR DESCRIPTION
To avoid external contributors getting errors during benchmark verification step:

```
Error: Command 'git' failed with args '-c user.name=github-action-benchmark -c user.email=github@users.noreply.github.com -c http.https://github.com/.extraheader= push ***github.com/folone/poi.scala.git gh-pages:gh-pages --no-verify': remote: Permission to folone/poi.scala.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/folone/poi.scala.git/': The requested URL returned error: 403
: Error: The process '/usr/bin/git' failed with exit code 128
```