### PR TITLE
Optimise benchmarks

### DIFF
--- a/.github/workflows/benchmark-comment.yml
+++ b/.github/workflows/benchmark-comment.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          fetch-depth: 0  # Fetch all history for all branches
+          fetch-depth: 0 # Fetch all history for all branches
       - name: Get PR number
         id: get-pr
         if: github.event.workflow_run.event == 'pull_request'
@@ -50,18 +50,64 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Download benchmark results
+      - name: Download all benchmark results
+        id: download-benchmarks
         uses: actions/download-artifact@v4
         with:
-          name: benchmark-results
+          pattern: "benchmark-results-*" # Download all benchmark result artifacts
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          merge-multiple: true # Merge all artifacts into a single directory
+        continue-on-error: true # Don't fail if no benchmark artifacts exist
+
+      - name: Check if benchmarks were downloaded
+        id: check-benchmarks
+        run: |
+          if ls benchmark-results-*.json 1> /dev/null 2>&1; then
+            echo "found=true" >> $GITHUB_OUTPUT
+            echo "Found benchmark result files:"
+            ls -la benchmark-results-*.json
+          else
+            echo "found=false" >> $GITHUB_OUTPUT
+            echo "No benchmark result files found - benchmarks may have been skipped"
+          fi
+
+      - name: Combine benchmark results
+        if: steps.check-benchmarks.outputs.found == 'true'
+        run: |
+          # Combine all benchmark JSON files into a single file for processing
+          echo "Combining benchmark results..."
+          if ls benchmark-results-*.json 1> /dev/null 2>&1; then
+            # Create a combined JSON array from all individual result files
+            echo "[" > combined-benchmark-results.json
+            first=true
+            for file in benchmark-results-*.json; do
+              if [ "$first" = true ]; then
+                first=false
+              else
+                echo "," >> combined-benchmark-results.json
+              fi
+              # Extract the benchmarks array content and append
+              jq '.[] | select(.benchmark != null)' "$file" >> combined-benchmark-results.json
+            done
+            echo "]" >> combined-benchmark-results.json
+            
+            # Flatten the nested structure
+            jq '[.[] | select(. != null)]' combined-benchmark-results.json > benchmark-results.json
+            
+            echo "Combined $(jq length benchmark-results.json) benchmark results"
+            ls -la benchmark-results.json
+          else
+            echo "No benchmark result files found"
+            echo "[]" > benchmark-results.json
+          fi
 
       - name: Compare benchmark results
+        if: steps.check-benchmarks.outputs.found == 'true'
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: JMH Benchmarks
-          tool: 'jmh'
+          tool: "jmh"
           output-file-path: benchmark-results.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
@@ -69,16 +115,39 @@ jobs:
           fail-on-alert: false
 
       - name: Post benchmark page link
-        if: github.event.workflow_run.event == 'pull_request' && steps.get-pr.outputs.pr-number != ''
+        if: github.event.workflow_run.event == 'pull_request' && steps.get-pr.outputs.pr-number != '' && steps.check-benchmarks.outputs.found == 'true'
         uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ steps.get-pr.outputs.pr-number }}
           body: |
             📊 **Benchmark Results**
 
-            The detailed benchmark results are available for review on our website.
+            Performance benchmarks have completed successfully! The detailed results are available for review:
 
             [View Benchmark Report](https://folone.github.io/poi.scala/dev/bench/)
+
+            **Benchmark Coverage:**
+            - ✅ Core POI operations (dataSize=1000)
+            - ✅ Async operations (dataSize=100) 
+            - ✅ Memory efficiency (dataSize=5000)
+
+            > 💡 **Note**: This is an optimized benchmark suite for faster PR feedback. 
+            > Comprehensive benchmarks with full parameter matrix run automatically on master branch.
+
+      - name: Post no benchmarks comment
+        if: github.event.workflow_run.event == 'pull_request' && steps.get-pr.outputs.pr-number != '' && steps.check-benchmarks.outputs.found == 'false'
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ steps.get-pr.outputs.pr-number }}
+          body: |
+            📊 **Benchmark Results**
+
+            No benchmark results were generated for this PR. This can happen when:
+            - Benchmarks were skipped due to compilation issues
+            - The workflow was triggered from a schedule event
+            - Benchmark jobs were filtered out due to conditions
+
+            If you expected benchmarks to run, please check the [workflow logs](${{ github.event.workflow_run.html_url }}) for details.
 
       - name: Log when PR number not found
         if: github.event.workflow_run.event == 'pull_request' && steps.get-pr.outputs.pr-number == ''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [master]
   schedule:
-  - cron: '0 0 * * 0'
+    - cron: "0 0 * * 0"
 
 jobs:
   # REQUIRED JOBS - These must pass for PR to be merged
@@ -12,25 +12,25 @@ jobs:
     name: Code Quality & Formatting
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-java@v4
-      with:
-        java-version: 11
-        distribution: temurin
-    - uses: coursier/cache-action@v6
-    - uses: sbt/setup-sbt@v1
-    - name: Check code formatting
-      run: sbt scalafmtSbtCheck "+scalafmtCheckAll"
-    - name: Compile and check for warnings
-      run: |
-        if sbt "+compile"; then
-          echo "✅ Compilation successful"
-        else
-          echo "❌ Compilation failed - please check source code"
-          exit 1
-        fi
-    - name: Run scalastyle
-      run: sbt scalastyle
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: 11
+          distribution: temurin
+      - uses: coursier/cache-action@v6
+      - uses: sbt/setup-sbt@v1
+      - name: Check code formatting
+        run: sbt scalafmtSbtCheck "+scalafmtCheckAll"
+      - name: Compile and check for warnings
+        run: |
+          if sbt "+compile"; then
+            echo "✅ Compilation successful"
+          else
+            echo "❌ Compilation failed - please check source code"
+            exit 1
+          fi
+      - name: Run scalastyle
+        run: sbt scalastyle
 
   test:
     name: Test Suite (${{ matrix.java }}, ${{ matrix.os }})
@@ -48,34 +48,34 @@ jobs:
           - java: 17
             os: ubuntu-latest
     steps:
-    - run: "git config --global core.autocrlf false"
-      shell: bash
-    - uses: actions/checkout@v4
-    - uses: actions/setup-java@v4
-      with:
-        java-version: "${{ matrix.java }}"
-        distribution: temurin
-    - uses: coursier/cache-action@v6
-    - uses: sbt/setup-sbt@v1
-    - name: Run comprehensive test suite
-      shell: bash
-      run: |
-        # First check if compilation works
-        if ! sbt "Test/compile"; then
-          echo "❌ Test compilation failed"
-          exit 1
-        fi
-        
-        # Then run tests
-        sbt -v \
-          "+compile" \
-          "+test"
-    - name: Upload test results
-      uses: actions/upload-artifact@v4
-      if: always()
-      with:
-        name: test-results-${{ matrix.java }}-${{ matrix.os }}
-        path: target/test-reports/
+      - run: "git config --global core.autocrlf false"
+        shell: bash
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: "${{ matrix.java }}"
+          distribution: temurin
+      - uses: coursier/cache-action@v6
+      - uses: sbt/setup-sbt@v1
+      - name: Run comprehensive test suite
+        shell: bash
+        run: |
+          # First check if compilation works
+          if ! sbt "Test/compile"; then
+            echo "❌ Test compilation failed"
+            exit 1
+          fi
+
+          # Then run tests
+          sbt -v \
+            "+compile" \
+            "+test"
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results-${{ matrix.java }}-${{ matrix.os }}
+          path: target/test-reports/
 
   property-based-testing:
     name: Extended Property-Based Testing
@@ -84,38 +84,38 @@ jobs:
       matrix:
         scala-version: ["2.12.20", "2.13.16", "3.3.6"]
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-java@v4
-      with:
-        java-version: 11
-        distribution: temurin
-    - uses: coursier/cache-action@v6
-    - uses: sbt/setup-sbt@v1
-    - name: Run extended property-based tests
-      run: |
-        sbt "++${{ matrix.scala-version }}" \
-          "testOnly info.folone.scala.poi.PropertyBasedTestingSpec" \
-          "testOnly info.folone.scala.poi.TypeclassLawsSpec"
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: 11
+          distribution: temurin
+      - uses: coursier/cache-action@v6
+      - uses: sbt/setup-sbt@v1
+      - name: Run extended property-based tests
+        run: |
+          sbt "++${{ matrix.scala-version }}" \
+            "testOnly info.folone.scala.poi.PropertyBasedTestingSpec" \
+            "testOnly info.folone.scala.poi.TypeclassLawsSpec"
 
   integration-testing:
     name: Integration Tests
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-java@v4
-      with:
-        java-version: 11
-        distribution: temurin
-    - uses: coursier/cache-action@v6
-    - uses: sbt/setup-sbt@v1
-    - name: Run integration tests
-      run: |
-        sbt "testOnly info.folone.scala.poi.IntegrationSpec"
-    - name: Validate generated files
-      run: |
-        find . -name "*.xlsx" -type f | head -5
-        echo "✅ Excel files generated successfully"
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: 11
+          distribution: temurin
+      - uses: coursier/cache-action@v6
+      - uses: sbt/setup-sbt@v1
+      - name: Run integration tests
+        run: |
+          sbt "testOnly info.folone.scala.poi.IntegrationSpec"
+      - name: Validate generated files
+        run: |
+          find . -name "*.xlsx" -type f | head -5
+          echo "✅ Excel files generated successfully"
 
   # OPTIONAL JOBS - These can fail without blocking PR merge
   performance-benchmarks:
@@ -123,51 +123,51 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'schedule'
     needs: [test]
-    continue-on-error: true  # Don't fail the entire workflow if benchmarks fail
+    continue-on-error: true # Don't fail the entire workflow if benchmarks fail
     strategy:
       matrix:
         benchmark-type: ["core", "async", "memory"]
       fail-fast: false
     steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0  # Need full history for performance comparison
-    - uses: actions/setup-java@v4
-      with:
-        java-version: 11
-        distribution: temurin
-    - uses: coursier/cache-action@v6
-    - uses: sbt/setup-sbt@v1
-    - name: Check if JMH compiles
-      run: |
-        if sbt "benchmarks/Jmh/compile"; then
-          echo "✅ JMH compilation successful"
-        else
-          echo "❌ JMH compilation failed, skipping benchmarks"
-          exit 0
-        fi
-    - name: Run optimized JMH benchmarks
-      run: |
-        case "${{ matrix.benchmark-type }}" in
-          "core")
-            # Run core benchmarks with reduced parameters for faster execution
-            sbt "benchmarks/Jmh/run -p dataSize=1000 -rf json -rff benchmark-results-core.json .*PoiBenchmarks.*" || echo "Core benchmarks failed but continuing"
-            ;;
-          "async")
-            # Run async benchmarks with smaller dataset
-            sbt "benchmarks/Jmh/run -p dataSize=100 -rf json -rff benchmark-results-async.json .*AsyncPoiBenchmarks.*" || echo "Async benchmarks failed but continuing"
-            ;;
-          "memory")
-            # Run memory benchmarks with single data size for efficiency
-            export SBT_OPTS="-Xmx2g -XX:+UseG1GC"
-            sbt "benchmarks/Jmh/run -p dataSize=5000 -rf json -rff benchmark-results-memory.json .*MemoryBenchmarks.*" || echo "Memory benchmarks failed but continuing"
-            ;;
-        esac
-    - name: Store benchmark results
-      uses: actions/upload-artifact@v4
-      with:
-        name: benchmark-results-${{ matrix.benchmark-type }}
-        path: benchmarks/benchmark-results-*.json
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Need full history for performance comparison
+      - uses: actions/setup-java@v4
+        with:
+          java-version: 11
+          distribution: temurin
+      - uses: coursier/cache-action@v6
+      - uses: sbt/setup-sbt@v1
+      - name: Check if JMH compiles
+        run: |
+          if sbt "benchmarks/Jmh/compile"; then
+            echo "✅ JMH compilation successful"
+          else
+            echo "❌ JMH compilation failed, skipping benchmarks"
+            exit 0
+          fi
+      - name: Run optimized JMH benchmarks
+        run: |
+          case "${{ matrix.benchmark-type }}" in
+            "core")
+              # Run core benchmarks with reduced parameters for faster execution
+              sbt "benchmarks/Jmh/run -p dataSize=1000 -rf json -rff benchmark-results-core.json .*PoiBenchmarks.*" || echo "Core benchmarks failed but continuing"
+              ;;
+            "async")
+              # Run async benchmarks with smaller dataset
+              sbt "benchmarks/Jmh/run -p dataSize=100 -rf json -rff benchmark-results-async.json .*AsyncPoiBenchmarks.*" || echo "Async benchmarks failed but continuing"
+              ;;
+            "memory")
+              # Run memory benchmarks with single data size for efficiency
+              export SBT_OPTS="-Xmx2g -XX:+UseG1GC"
+              sbt "benchmarks/Jmh/run -p dataSize=5000 -rf json -rff benchmark-results-memory.json .*MemoryBenchmarks.*" || echo "Memory benchmarks failed but continuing"
+              ;;
+          esac
+      - name: Store benchmark results
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results-${{ matrix.benchmark-type }}
+          path: benchmarks/benchmark-results-*.json
 
   # Full comprehensive benchmarks - only run on master branch push
   comprehensive-benchmarks:
@@ -177,29 +177,29 @@ jobs:
     needs: [test]
     continue-on-error: true
     steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-    - uses: actions/setup-java@v4
-      with:
-        java-version: 11
-        distribution: temurin
-    - uses: coursier/cache-action@v6
-    - uses: sbt/setup-sbt@v1
-    - name: Run full benchmark suite
-      run: |
-        # Run all benchmarks with all parameter combinations (comprehensive)
-        export SBT_OPTS="-Xmx4g -XX:+UseG1GC"
-        sbt "benchmarks/Jmh/run -rf json -rff comprehensive-results.json" || echo "Comprehensive benchmarks failed but continuing"
-    - name: Compare comprehensive benchmark results
-      uses: benchmark-action/github-action-benchmark@v1
-      with:
-        name: JMH Comprehensive Benchmarks
-        tool: 'jmh'
-        output-file-path: benchmarks/comprehensive-results.json
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        auto-push: true
-        fail-on-alert: false
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v4
+        with:
+          java-version: 11
+          distribution: temurin
+      - uses: coursier/cache-action@v6
+      - uses: sbt/setup-sbt@v1
+      - name: Run full benchmark suite
+        run: |
+          # Run all benchmarks with all parameter combinations (comprehensive)
+          export SBT_OPTS="-Xmx4g -XX:+UseG1GC"
+          sbt "benchmarks/Jmh/run -rf json -rff comprehensive-results.json" || echo "Comprehensive benchmarks failed but continuing"
+      - name: Compare comprehensive benchmark results
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: JMH Comprehensive Benchmarks
+          tool: "jmh"
+          output-file-path: benchmarks/comprehensive-results.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          fail-on-alert: false
 
   # REQUIRED STATUS CHECK - All critical jobs must pass
   required-checks:
@@ -208,22 +208,22 @@ jobs:
     needs: [code-quality, test, property-based-testing, integration-testing]
     if: always()
     steps:
-    - name: Check build status
-      run: |
-        echo "🔍 Required Check Results:"
-        echo "Code Quality: ${{ needs.code-quality.result }}"
-        echo "Test Suite: ${{ needs.test.result }}"
-        echo "Property-Based Testing: ${{ needs.property-based-testing.result }}"
-        echo "Integration Testing: ${{ needs.integration-testing.result }}"
-        
-        # All required jobs must succeed
-        if [[ "${{ needs.code-quality.result }}" == "success" && 
-              "${{ needs.test.result }}" == "success" && 
-              "${{ needs.property-based-testing.result }}" == "success" && 
-              "${{ needs.integration-testing.result }}" == "success" ]]; then
-          echo "✅ All required checks passed!"
-          echo "Note: Performance benchmarks and memory tests are optional"
-        else
-          echo "❌ Some required checks failed"
-          exit 1
-        fi
+      - name: Check build status
+        run: |
+          echo "🔍 Required Check Results:"
+          echo "Code Quality: ${{ needs.code-quality.result }}"
+          echo "Test Suite: ${{ needs.test.result }}"
+          echo "Property-Based Testing: ${{ needs.property-based-testing.result }}"
+          echo "Integration Testing: ${{ needs.integration-testing.result }}"
+
+          # All required jobs must succeed
+          if [[ "${{ needs.code-quality.result }}" == "success" && 
+                "${{ needs.test.result }}" == "success" && 
+                "${{ needs.property-based-testing.result }}" == "success" && 
+                "${{ needs.integration-testing.result }}" == "success" ]]; then
+            echo "✅ All required checks passed!"
+            echo "Note: Performance benchmarks and memory tests are optional"
+          else
+            echo "❌ Some required checks failed"
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,10 @@ jobs:
     if: github.event_name != 'schedule'
     needs: [test]
     continue-on-error: true  # Don't fail the entire workflow if benchmarks fail
+    strategy:
+      matrix:
+        benchmark-type: ["core", "async", "memory"]
+      fail-fast: false
     steps:
     - uses: actions/checkout@v4
       with:
@@ -142,51 +146,59 @@ jobs:
           echo "❌ JMH compilation failed, skipping benchmarks"
           exit 0
         fi
-    - name: Run JMH benchmarks
+    - name: Run optimized JMH benchmarks
       run: |
-        sbt "benchmarks/Jmh/run -rf json -rff benchmark-results.json .*PoiBenchmarks.*" || echo "Benchmarks failed but continuing"
+        case "${{ matrix.benchmark-type }}" in
+          "core")
+            # Run core benchmarks with reduced parameters for faster execution
+            sbt "benchmarks/Jmh/run -p dataSize=1000 -rf json -rff benchmark-results-core.json .*PoiBenchmarks.*" || echo "Core benchmarks failed but continuing"
+            ;;
+          "async")
+            # Run async benchmarks with smaller dataset
+            sbt "benchmarks/Jmh/run -p dataSize=100 -rf json -rff benchmark-results-async.json .*AsyncPoiBenchmarks.*" || echo "Async benchmarks failed but continuing"
+            ;;
+          "memory")
+            # Run memory benchmarks with single data size for efficiency
+            export SBT_OPTS="-Xmx2g -XX:+UseG1GC"
+            sbt "benchmarks/Jmh/run -p dataSize=5000 -rf json -rff benchmark-results-memory.json .*MemoryBenchmarks.*" || echo "Memory benchmarks failed but continuing"
+            ;;
+        esac
     - name: Store benchmark results
       uses: actions/upload-artifact@v4
       with:
-        name: benchmark-results
-        path: benchmarks/benchmark-results.json
+        name: benchmark-results-${{ matrix.benchmark-type }}
+        path: benchmarks/benchmark-results-*.json
 
-  memory-testing:
-    name: Memory & Stress Testing
+  # Full comprehensive benchmarks - only run on master branch push
+  comprehensive-benchmarks:
+    name: Comprehensive Performance Suite
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     needs: [test]
-    continue-on-error: true  # Don't fail workflow if memory tests fail
+    continue-on-error: true
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - uses: actions/setup-java@v4
       with:
         java-version: 11
         distribution: temurin
     - uses: coursier/cache-action@v6
     - uses: sbt/setup-sbt@v1
-    - name: Check if memory benchmarks compile
+    - name: Run full benchmark suite
       run: |
-        if sbt "benchmarks/Jmh/compile"; then
-          echo "✅ JMH compilation successful for memory tests"
-        else
-          echo "❌ JMH compilation failed, skipping memory tests"
-          exit 0
-        fi
-    - name: Run memory benchmarks
-      run: |
-        # Run with larger heap for memory testing
-        export SBT_OPTS="-Xmx2g -XX:+UseG1GC"
-        sbt "benchmarks/Jmh/run -rf json -rff memory-results.json .*MemoryBenchmarks.*" || echo "Memory benchmarks failed but continuing"
-    - name: Compare memory benchmark results
+        # Run all benchmarks with all parameter combinations (comprehensive)
+        export SBT_OPTS="-Xmx4g -XX:+UseG1GC"
+        sbt "benchmarks/Jmh/run -rf json -rff comprehensive-results.json" || echo "Comprehensive benchmarks failed but continuing"
+    - name: Compare comprehensive benchmark results
       uses: benchmark-action/github-action-benchmark@v1
       with:
-        name: JMH Memory Benchmarks
+        name: JMH Comprehensive Benchmarks
         tool: 'jmh'
-        output-file-path: benchmarks/memory-results.json
+        output-file-path: benchmarks/comprehensive-results.json
         github-token: ${{ secrets.GITHUB_TOKEN }}
         auto-push: true
-        # Do not fail the build, just comment on the PR.
         fail-on-alert: false
 
   # REQUIRED STATUS CHECK - All critical jobs must pass

--- a/benchmarks/src/jmh/scala/info/folone/scala/poi/benchmarks/AsyncPoiBenchmarks.scala
+++ b/benchmarks/src/jmh/scala/info/folone/scala/poi/benchmarks/AsyncPoiBenchmarks.scala
@@ -12,11 +12,11 @@ import scala.concurrent.duration._
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
 @Fork(1)
-@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 class AsyncPoiBenchmarks {
 
-  @Param(Array("100", "1000"))
+  @Param(Array("100"))
   var dataSize: Int = _
 
   var workbook: Workbook = _

--- a/benchmarks/src/jmh/scala/info/folone/scala/poi/benchmarks/ComprehensivePoiBenchmarks.scala
+++ b/benchmarks/src/jmh/scala/info/folone/scala/poi/benchmarks/ComprehensivePoiBenchmarks.scala
@@ -1,0 +1,174 @@
+package info.folone.scala.poi.benchmarks
+
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+import info.folone.poi._
+import info.folone.poi.scalaz._
+import java.util.Date
+import scala.util.Random
+import _root_.scalaz.syntax.semigroup._
+
+/**
+ * Comprehensive benchmarks with full parameter matrix - only run on master branch
+ * This is the full suite that was previously in PoiBenchmarks.scala
+ */
+@BenchmarkMode(Array(Mode.Throughput, Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Fork(1)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+class ComprehensivePoiBenchmarks {
+
+  @Param(Array("100", "1000", "5000"))
+  var dataSize: Int = _
+
+  var largeWorkbook: Workbook = _
+  var smallWorkbook: Workbook = _
+  var mediumWorkbook: Workbook = _
+  var testData: Seq[Seq[String]] = _
+
+  @Setup(Level.Trial)
+  def setupData(): Unit = {
+    val random = new Random(42)
+
+    testData = (1 to dataSize).map {
+      row =>
+        (1 to 10).map {
+          col =>
+            s"Data-${row}-${col}-${random.nextInt(1000)}"
+        }
+    }
+
+    largeWorkbook = BenchmarkUtils.createWorkbook(5000, "Large")
+    smallWorkbook = BenchmarkUtils.createWorkbook(100, "Small")
+    mediumWorkbook = BenchmarkUtils.createWorkbook(1000, "Medium")
+  }
+
+  @Benchmark
+  def cellCreationBenchmark(bh: Blackhole): Unit = {
+    val cells = (0 until dataSize).map {
+      i =>
+        StringCell(i, s"BenchmarkCell-$i")
+    }
+    bh.consume(cells)
+  }
+
+  @Benchmark
+  def rowCreationBenchmark(bh: Blackhole): Unit = {
+    val rows = (0 until dataSize).map {
+      rowIndex =>
+        val cells: Set[Cell] = (0 until 10).map {
+          colIndex =>
+            StringCell(colIndex, s"Row-$rowIndex-Col-$colIndex"): Cell
+        }.toSet
+        Row(rowIndex)(cells)
+    }
+    bh.consume(rows)
+  }
+
+  @Benchmark
+  def sheetCreationBenchmark(bh: Blackhole): Unit = {
+    val random = new Random(42)
+    val rows = (0 until dataSize).map {
+      rowIndex =>
+        val cells: Set[Cell] = (0 until 10).map {
+          colIndex =>
+            StringCell(colIndex, s"Sheet-$rowIndex-Col-$colIndex"): Cell
+        }.toSet
+        Row(rowIndex)(cells)
+    }.toSet
+
+    val sheet = Sheet("BenchmarkSheet")(rows)
+    bh.consume(sheet)
+  }
+
+  @Benchmark
+  def workbookCreationBenchmark(bh: Blackhole): Unit = {
+    val workbook = BenchmarkUtils.createWorkbook(dataSize, "Benchmark")
+    bh.consume(workbook)
+  }
+
+  @Benchmark
+  def cellLookupBenchmark(bh: Blackhole): Unit = {
+    val sheet = largeWorkbook.sheets.head
+    val results = (0 until 100).map {
+      i =>
+        sheet.rows.find(_.index == i % dataSize)
+    }
+    bh.consume(results)
+  }
+
+  @Benchmark
+  def dataTransformationBenchmark(bh: Blackhole): Unit = {
+    val sheet = largeWorkbook.sheets.head
+    val transformedRows = sheet.rows.map {
+      row =>
+        val newCells = row.cells.map {
+          case StringCell(index, data) => StringCell(index, data.toUpperCase)
+          case other => other
+        }
+        Row(row.index)(newCells)
+    }
+    bh.consume(transformedRows)
+  }
+
+  @Benchmark
+  def formulaCellsBenchmark(bh: Blackhole): Unit = {
+    val formulas = Seq(
+      "SUM(A1:A10)",
+      "AVERAGE(B1:B100)",
+      "MAX(C1:C50)",
+      "MIN(D1:D25)",
+      "COUNT(E1:E75)"
+    )
+
+    val cells = (0 until dataSize).map {
+      i =>
+        FormulaCell(i, formulas(i % formulas.length))
+    }
+    bh.consume(cells)
+  }
+
+  @Benchmark
+  def unicodeDataBenchmark(bh: Blackhole): Unit = {
+    val unicodeData = Seq(
+      "测试数据",
+      "テストデータ",
+      "тестові дані",
+      "δοκιμαστικά δεδομένα",
+      "données de test"
+    )
+
+    val cells = (0 until dataSize).map {
+      i =>
+        StringCell(i, unicodeData(i % unicodeData.length))
+    }
+    bh.consume(cells)
+  }
+
+  @Benchmark
+  def workbookCombinationBenchmark(bh: Blackhole): Unit = {
+    val combined = smallWorkbook |+| mediumWorkbook
+    bh.consume(combined)
+  }
+
+  @Benchmark
+  def memoryIntensiveBenchmark(bh: Blackhole): Unit = {
+    val workbooks = (1 to 10).map {
+      i =>
+        BenchmarkUtils.createWorkbook(dataSize / 10, s"Memory-$i")
+    }
+
+    val combined = workbooks.reduce(_ |+| _)
+    bh.consume(combined)
+  }
+
+  @Benchmark
+  def bulkDataProcessingBenchmark(bh: Blackhole): Unit = {
+    val workbooks = (0 until 20).map(i => BenchmarkUtils.createWorkbook(50, s"Bulk-$i"))
+    val combined = workbooks.reduce((wb1, wb2) => wb1 |+| wb2)
+    bh.consume(combined.toString)
+  }
+}

--- a/benchmarks/src/jmh/scala/info/folone/scala/poi/benchmarks/MemoryBenchmarks.scala
+++ b/benchmarks/src/jmh/scala/info/folone/scala/poi/benchmarks/MemoryBenchmarks.scala
@@ -16,11 +16,11 @@ import _root_.scalaz.syntax.semigroup._
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
 @Fork(1)
-@Warmup(iterations = 3)
-@Measurement(iterations = 5)
+@Warmup(iterations = 2)
+@Measurement(iterations = 3)
 class MemoryBenchmarks {
 
-  @Param(Array("1000", "5000", "10000"))
+  @Param(Array("5000"))
   var dataSize: Int = _
 
   @Benchmark


### PR DESCRIPTION
Benchmarks take a long time to complete – over 20 minutes per PR currently.
This change runs only the minimal core benchmark harness for PRs (and a full comprehensive set of benchmarks on merge to master).